### PR TITLE
Fixed output for OrbPeriod and MeanMotion

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -702,7 +702,7 @@ void WriteOrbMeanMotion(BODY *body, CONTROL *control, OUTPUT *output,
     *dTmp *= output->dNeg;
     strcpy(cUnit, output->cNeg);
   } else {
-    *dTmp /= fdUnitsTime(units->iTime);
+    *dTmp *= fdUnitsTime(units->iTime);
     fsUnitsRate(units->iTime, cUnit);
   }
 }
@@ -735,7 +735,7 @@ void WriteOrbPeriod(BODY *body, CONTROL *control, OUTPUT *output,
     *dTmp *= output->dNeg;
     strcpy(cUnit, output->cNeg);
   } else {
-    *dTmp *= fdUnitsTime(units->iTime);
+    *dTmp /= fdUnitsTime(units->iTime); 
     fsUnitsTime(units->iTime, cUnit);
   }
 }


### PR DESCRIPTION
## Proposed changes

Fixed output for OrbPeriod and MeanMotion. The previous version incorrectly scaled the output if the user did not specify the custom unit.

## Types of changes

What types of changes does your PR introduce to VPLanet?

- [ x ] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New module (non-breaking change that adds a new module)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update 

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x ] I have adhered to the [Style ](https://virtualplanetarylaboratory.github.io/vplanet/StyleGuide.html) or run the clang format code shown [here](https://virtualplanetarylaboratory.github.io/vplanet/StyleGuide.html#c-code-formatting)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run Valgrind on new tests to ensure no errors were found
- [ ] (Optional) I have added an example showcasing the new change

## Further comments

