### PR TITLE
Fix of unit issue in EarthClimate example plot

### DIFF
--- a/examples/EarthClimate/earth.in
+++ b/examples/EarthClimate/earth.in
@@ -48,4 +48,4 @@ dMixingDepth 70
 dNuLandWater 0.8
 bElevFB 0
 dRefHeight 400
-dSeasOutputTime 1e6
+dSeasOutputTime 0

--- a/examples/EarthClimate/earth.in
+++ b/examples/EarthClimate/earth.in
@@ -48,3 +48,4 @@ dMixingDepth 70
 dNuLandWater 0.8
 bElevFB 0
 dRefHeight 400
+dSeasOutputTime 1e6

--- a/examples/EarthClimate/makeplot.py
+++ b/examples/EarthClimate/makeplot.py
@@ -89,11 +89,12 @@ def comp2huybers(plname, xrange=False, show=True):
                 pco2 = np.float(lines[i].split()[1])
 
     try:
-        longp = (body.ArgP + body.LongA + body.PrecA + 180) * np.pi / 180.0
+        longp = (body.ArgP + body.LongA + body.PrecA + 180)
     except:
-        longp = body.PrecA * np.pi / 180.0
+        longp = body.PrecA
 
     esinv = ecc * np.sin(longp)
+    import pdb; pdb.set_trace()
 
     lats = np.unique(body.Latitude)
     nlats = len(lats)

--- a/examples/EarthClimate/makeplot.py
+++ b/examples/EarthClimate/makeplot.py
@@ -94,7 +94,6 @@ def comp2huybers(plname, xrange=False, show=True):
         longp = body.PrecA
 
     esinv = ecc * np.sin(longp)
-    import pdb; pdb.set_trace()
 
     lats = np.unique(body.Latitude)
     nlats = len(lats)


### PR DESCRIPTION
## Proposed changes

There is a unit issue in examples/EarthClimate/makeplot.py. It makes the plot of CPP wrong. I fixed the issue. Look at the code changes. 

## Types of changes

What types of changes does your PR introduce to VPLanet?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] New module (non-breaking change that adds a new module)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update 

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of the steps that are necessary before merging your PR._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have adhered to the [Style ](https://virtualplanetarylaboratory.github.io/vplanet/StyleGuide.html) or run the clang format code shown [here](https://virtualplanetarylaboratory.github.io/vplanet/StyleGuide.html#c-code-formatting)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have run Valgrind on new tests to ensure no errors were found
- [ ] (Optional) I have added an example showcasing the new change

## Further comments

If this is a relatively large or complex change, explain why you chose the solution you did, what alternatives you considered, or anything else you believe to be relevant.
