### PR TITLE
Adding the Engle 2023/2024 XUV and gyrochronology models

### DIFF
--- a/src/stellar.c
+++ b/src/stellar.c
@@ -1035,24 +1035,28 @@ void fnPropsAuxStellar(BODY *body, EVOLVE *evolve, IO *io, UPDATE *update,
 
     // Engle segmented power-law decay model
     double dAge  = body[iBody].dAge / (1.e9 * YEARSEC);
+    double logAge = log10(dAge);
+    double shift = -0.2985;
     //double dTMin = body[iBody].dSatXUVTime / (1.e9 * YEARSEC);
-    if (log10(dAge) >= -0.2985) {
-      body[iBody].dLXUV = pow(10., (-0.4896 * log10(dAge) - 3.2128 - 0.4469 *
-                          log10(dAge + 0.2985))) * body[iBody].dLuminosity;
+    if (logAge >= shift) {
+      body[iBody].dLXUV = pow(10., (-0.4896 * logAge - 3.2128 - 0.4469 *
+                          (logAge - shift))) * body[iBody].dLuminosity;
     } else {
-      body[iBody].dLXUV = pow(10., (-0.4896 * log10(dAge) - 3.2128)) *
+      body[iBody].dLXUV = pow(10., (-0.4896 * logAge - 3.2128)) *
                           body[iBody].dLuminosity;
     }
 
   } else if (body[iBody].iXUVModel == STELLAR_MODEL_ENGLE24MIDLATE) {
 
     // Engle segmented power-law decay model
-    double dAge  = body[iBody].dAge / (1.e9 * YEARSEC);
-    if (log10(dAge) >= 0.3545) {
-      body[iBody].dLXUV = pow(10., (-0.1456 * log10(dAge) - 2.8876 - 1.8187 *
-                          log10(dAge - 0.3545))) * body[iBody].dLuminosity;
+    double dAge   = body[iBody].dAge / (1.e9 * YEARSEC);
+    double logAge = log10(dAge);
+    double shift  = 0.3545;
+    if (logAge >= shift) {
+      body[iBody].dLXUV = pow(10., (-0.1456 * logAge - 2.8876 - 1.8187 *
+                          (logAge - shift))) * body[iBody].dLuminosity;
     } else {
-      body[iBody].dLXUV = pow(10., (-0.1456 * log10(dAge) - 2.8876)) *
+      body[iBody].dLXUV = pow(10., (-0.1456 * logAge - 2.8876)) *
                           body[iBody].dLuminosity;
     }
 
@@ -1421,7 +1425,7 @@ void WriteEmpirRotPerStellar(BODY *body, CONTROL *control, OUTPUT *output,
                 dEmpirRotPer = (logAge + 1.0437 + 0.0528 * (dRotPerOld - 23.4933)) / 0.0621;
             } while (fabs(dEmpirRotPer - dRotPerOld) > tolerance);
         }
-        *dTmp = dEmpirRotPer;
+        *dTmp = (dEmpirRotPer <= 1.0 ? 1.0 : dEmpirRotPer);
         fsUnitsTime(1, cUnit);
 
     } 
@@ -1443,7 +1447,7 @@ void WriteEmpirRotPerStellar(BODY *body, CONTROL *control, OUTPUT *output,
                 dEmpirRotPer = (logAge + 0.8900 + 0.0521 * (dRotPerOld - 24.1888)) / 0.0561;
             } while (fabs(dEmpirRotPer - dRotPerOld) > tolerance);
         }
-        *dTmp = dEmpirRotPer;
+        *dTmp = (dEmpirRotPer <= 1.0 ? 1.0 : dEmpirRotPer);
         fsUnitsTime(1, cUnit);
         
     } 
@@ -1465,7 +1469,7 @@ void WriteEmpirRotPerStellar(BODY *body, CONTROL *control, OUTPUT *output,
                 dEmpirRotPer = (logAge + 0.1615 + 0.0212 * (dRotPerOld - 25.45)) / 0.0251;
             } while (fabs(dEmpirRotPer - dRotPerOld) > tolerance);
         }
-        *dTmp = dEmpirRotPer;
+        *dTmp = (dEmpirRotPer <= 1.0 ? 1.0 : dEmpirRotPer);
         fsUnitsTime(1, cUnit);
 
     }
@@ -2237,5 +2241,77 @@ double fdLuminosityFunctionSineWave(BODY *body, int iBody) {
         body[iBody].dLuminosityAmplitude *
               sin(body[iBody].dAge * body[iBody].dLuminosityFrequency +
                   body[iBody].dLuminosityPhase);
+  return dLuminosity;
+}
+iError == STELLAR_ERR_OUTOFBOUNDS_LO) {
+      fprintf(stderr,
+              "ERROR: Temperature out of bounds (low) in fdBaraffe().\n");
+    } else if (iError == STELLAR_ERR_FILE) {
+      fprintf(stderr,
+              "ERROR: File access error in temperature routine fdBaraffe().\n");
+    } else if (iError == STELLAR_ERR_BADORDER) {
+      fprintf(stderr,
+              "ERROR: Bad temperature interpolation order in routine "
+              "fdBaraffe().\n");
+    } else {
+      fprintf(stderr, "ERROR: Undefined temperature error in fdBaraffe().\n");
+    }
+    exit(EXIT_INT);
+  }
+}
+
+double fdLuminosityFunctionProximaCen(double dAge, double dMass) {
+  int iError;
+  double L = fdProximaCenStellar(PROXIMACEN_L, dAge, dMass, &iError);
+  if (iError == PROXIMACEN_ERROR) {
+    return NAN;
+  } else {
+    return L;
+  }
+}
+
+double fdTemperatureFunctionProximaCen(double dAge, double dMass) {
+  int iError;
+  double L = fdProximaCenStellar(PROXIMACEN_T, dAge, dMass, &iError);
+  if (iError == PROXIMACEN_ERROR) {
+    return NAN;
+  } else {
+    return L;
+  }
+}
+
+double fdRadiusFunctionProximaCen(double dAge, double dMass) {
+  int iError;
+  double L = fdProximaCenStellar(PROXIMACEN_R, dAge, dMass, &iError);
+  if (iError == PROXIMACEN_ERROR) {
+    return NAN;
+  } else {
+    return L;
+  }
+}
+
+/* Compute the convective turnover timescale (in seconds) based on Equation 36
+   from Cranmer and Saar 2011.  This equation is valid for 3300 <= Teff <= 7000
+   K, which pretty much brackets all stellar evolution models considered in
+   stellar.
+*/
+double fdCranmerSaar2011TauCZ(double Teff) {
+  double tau =
+        314.24 * exp(-(Teff / 1952.5) - pow((Teff / 6250.0), 18)) + 0.002;
+  return tau * 86400.0;
+}
+
+double fdSurfEnFluxStellar(BODY *body, SYSTEM *system, UPDATE *update,
+                           int iBody, int iFoo) {
+  // This is silly, but necessary!
+  // RORY: I don't think so! -- This function should be set to ReturnOutputZero
+  return 0;
+}
+
+double fdLuminosityFunctionSineWave(BODY *body, int iBody) {
+  double dLuminosity =
+      body[iBody].dLuminosityInitial + body[iBody].dLuminosityAmplitude *
+      sin(body[iBody].dAge * body[iBody].dLuminosityFrequency +
+      body[iBody].dLuminosityPhase);
   return dLuminosity;
 }

--- a/src/stellar.h
+++ b/src/stellar.h
@@ -199,3 +199,9 @@ double fdCranmerSaar2011TauCZ(double);
 double fdSurfEnFluxStellar(BODY *, SYSTEM *, UPDATE *, int, int);
 
 /* @endcond */
+ fdCranmerSaar2011TauCZ(double);
+
+/* Dummy functions */
+double fdSurfEnFluxStellar(BODY *, SYSTEM *, UPDATE *, int, int);
+
+/* @endcond */

--- a/src/stellar.h
+++ b/src/stellar.h
@@ -42,6 +42,12 @@
 #define STELLAR_MODEL_PROXIMACEN 5
 #define STELLAR_MODEL_SINEWAVE 6
 
+#define STELLAR_DJDT_ENGLE23EARLY 7				
+#define STELLAR_DJDT_ENGLE23MIDLATE 8
+#define STELLAR_DJDT_ENGLE23LATE 9
+#define STELLAR_MODEL_ENGLE24EARLY 10
+#define STELLAR_MODEL_ENGLE24MIDLATE 11
+
 #define STELLAR_DJDT_NONE                                                      \
   0 /**< No stellar angular momentum loss via magnetic braking */
 #define STELLAR_DJDT_RM12 1 /**< dJ/dt according to Reiners & Mohanty 2012 */
@@ -95,6 +101,7 @@
 #define OUT_ROSSBYNUMBER 1514
 #define OUT_DROTPERDTSTELLAR 1515
 #define OUT_WINDTORQUE 1516
+#define OUT_EMPIRROTPERSTELLAR 1517
 
 /* @cond DOXYGEN_OVERRIDE */
 


### PR DESCRIPTION
## Proposed changes

Added new models for XUV calculations, and magnetic braking

## Types of changes

All modifications are in stellar.c and stellar.h

The XUV models are pretty smoothly integrated

The braking models were integrated with their own 'empirical' variable because I wasn't exactly sure how to disable other calculations that were also influencing the rotations. Rory has figured it out on his end, so there will be a cleaner way to integrate the braking models. 